### PR TITLE
Add spoilers to posts and comments

### DIFF
--- a/src/components/Comments/CommentItem.tsx
+++ b/src/components/Comments/CommentItem.tsx
@@ -8,6 +8,7 @@ import {
 	Modal,
 	Button,
 	Alert,
+	Spoiler,
 } from "@mantine/core";
 import { RichTextEditor } from "@mantine/tiptap";
 import { IconCheck, IconDots, IconEdit, IconTrash } from "@tabler/icons-react";
@@ -233,7 +234,12 @@ export default function CommentItem(props: CommentItemProps) {
 									"& .ProseMirror": { padding: "0" },
 								},
 							}}>
-							<RichTextEditor.Content />
+							<Spoiler
+								maxHeight={300}
+								showLabel="Show more"
+								hideLabel="Show less">
+								<RichTextEditor.Content />
+							</Spoiler>
 						</RichTextEditor>
 					)}
 				</div>

--- a/src/components/PostItem/PostItem.tsx
+++ b/src/components/PostItem/PostItem.tsx
@@ -9,6 +9,7 @@ import {
 	Divider,
 	Menu,
 	Modal,
+	Spoiler,
 	useMantineTheme,
 } from "@mantine/core";
 import { PublicPostFull } from "@/types/types";
@@ -247,7 +248,12 @@ export default function PostItem(props: PostItemProps) {
 									root: { border: "none" },
 									content: { "& .ProseMirror": { padding: "0" } },
 								}}>
-								<RichTextEditor.Content />
+								<Spoiler
+									maxHeight={400}
+									showLabel="Show more"
+									hideLabel="Show less">
+									<RichTextEditor.Content />
+								</Spoiler>
 							</RichTextEditor>
 						)}
 					</div>


### PR DESCRIPTION
Add spoilers to posts and comments so long posts and comments don't take up too much space.
![image](https://github.com/TruePadawan/Anon/assets/71678062/bfddbfb3-e52f-4340-8148-ea5532275d2f)
