### PR TITLE
Add a relation between UserProfile and User collection

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,8 @@ model UserProfile {
   color       String
   displayName String
   createdAt   Int
+  user        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId      String        @unique @db.ObjectId
   PublicPost  PublicPost[]
   Comment     Comment[]
   Group       Group[]
@@ -49,14 +51,15 @@ model UserProfile {
 }
 
 model User {
-  id            String    @id @default(auto()) @map("_id") @db.ObjectId
-  email         String?   @unique
+  id            String       @id @default(auto()) @map("_id") @db.ObjectId
+  email         String?      @unique
   /// Could not determine type: the field only had null or empty values in the sample set.
   emailVerified DateTime?
   image         String?
   name          String?
   Account       Account[]
   Session       Session[]
+  profile       UserProfile?
 }
 
 model PublicPost {

--- a/src/pages/api/complete-auth.ts
+++ b/src/pages/api/complete-auth.ts
@@ -14,7 +14,7 @@ export default async function handler(
 	const session = await getServerSession(req, res, authOptions);
 	if (session) {
 		const profile = await prisma.userProfile.findUnique({
-			where: { id: session.user.id },
+			where: { userId: session.user.id },
 			select: { accountName: true },
 		});
 		if (profile) {

--- a/src/pages/api/create-profile.ts
+++ b/src/pages/api/create-profile.ts
@@ -18,7 +18,7 @@ export default async function handler(
 		} else {
 			try {
 				const profile = await prisma.userProfile.create({
-					data: JSON.parse(req.body),
+					data: { ...JSON.parse(req.body), userId: session.user.id },
 				});
 				res
 					.status(200)

--- a/src/pages/api/get-user-profile.ts
+++ b/src/pages/api/get-user-profile.ts
@@ -19,7 +19,7 @@ export default async function handler(
 			try {
 				const user = await prisma.userProfile.findUnique({
 					where: {
-						id: session.user.id,
+						userId: session.user.id,
 					},
 				});
 				res.status(200).json({ user });

--- a/src/pages/api/update-profile.ts
+++ b/src/pages/api/update-profile.ts
@@ -19,7 +19,7 @@ export default async function handler(
 			try {
 				await prisma.userProfile.update({
 					where: {
-						id: session.user.id,
+						userId: session.user.id,
 					},
 					data: JSON.parse(req.body),
 				});

--- a/src/pages/api/validate-account-name.ts
+++ b/src/pages/api/validate-account-name.ts
@@ -13,7 +13,7 @@ export default async function handler(
 	} else {
 		const currentUser = await prisma.userProfile.findUnique({
 			where: {
-				id: session.user.id,
+				userId: session.user.id,
 			},
 			select: {
 				accountName: true,

--- a/src/pages/create-profile/index.tsx
+++ b/src/pages/create-profile/index.tsx
@@ -61,7 +61,6 @@ export default function CreateProfilePage() {
 			setCreatingProfile(true);
 
 			const profileData = {
-				id: session?.user.id,
 				accountName: accountNameInput.value,
 				displayName: displayNameInput.value,
 				color: getRandomColor(),
@@ -168,7 +167,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 	}
 
 	const profile = await prisma.userProfile.findUnique({
-		where: { id: session.user.id },
+		where: { userId: session.user.id },
 		select: { accountName: true },
 	});
 

--- a/src/pages/users/index.tsx
+++ b/src/pages/users/index.tsx
@@ -15,9 +15,8 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
 	let redirectDestination = "/sign-in";
 
 	if (session) {
-		const userID = session.user.id;
 		const profile = await prisma.userProfile.findUnique({
-			where: { id: userID },
+			where: { userId: session.user.id },
 			select: { accountName: true },
 		});
 		if (profile) {


### PR DESCRIPTION
This commit adds a one-to-one relation between the UserProfile and User collection. A profile can have a truly random id and not the same id as the corresponding User document. This commits also updates parts of the code that are affected by this schema change.